### PR TITLE
Continue embedding the window when ProcessJobTracker fails

### DIFF
--- a/src/RoyalApps.Community.ExternalApps.WinForms/ExternalApps.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/ExternalApps.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
+using Microsoft.Extensions.Logging;
 using RoyalApps.Community.ExternalApps.WinForms.WindowManagement;
 
 namespace RoyalApps.Community.ExternalApps.WinForms;
@@ -35,7 +36,7 @@ public static class ExternalApps
         ProcessJobTracker.Dispose();
     }
 
-    internal static HWND EmbedWindow(HWND parentWindowHandle, HWND childWindowHandle, Process? process)
+    internal static HWND EmbedWindow(HWND parentWindowHandle, HWND childWindowHandle, Process? process, ILogger logger)
     {
         if (!_isInitialized)
             throw new InvalidOperationException("Cannot call EmbedWindow without calling 'ExternalApps.Initialize()' first.");
@@ -49,8 +50,20 @@ public static class ExternalApps
             parentWindowClientRect.right - parentWindowClientRect.left, 
             parentWindowClientRect.bottom - parentWindowClientRect.top);
 
-        if (process != null) 
-            ProcessJobTracker.AddProcess(process);
+        try
+        {
+            if (process != null) 
+                ProcessJobTracker.AddProcess(process);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex, 
+                "ProcessJobTracker could not add the process {FileName} with the id {Id}", 
+                process?.StartInfo.FileName, 
+                process?.Id
+                );
+        }
 
         return new HWND(containerHandle);
     }

--- a/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
@@ -11,7 +11,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>RoyalApps_1024.png</PackageIcon>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>0.3.0</Version>
+        <Version>0.3.1</Version>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ExternalApp.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ExternalApp.cs
@@ -488,7 +488,7 @@ internal sealed class ExternalApp : IDisposable
                 OriginalWindowHandle = WindowHandle;
                 ownerControl.Invoke(() =>
                 {
-                    WindowHandle = ExternalApps.EmbedWindow(ownerControl.ControlHandle, WindowHandle, Process);
+                    WindowHandle = ExternalApps.EmbedWindow(ownerControl.ControlHandle, WindowHandle, Process, _logger);
                 });
                 IsEmbedded = true;
                 break;


### PR DESCRIPTION
In Response to #1 

ProcessJobTracker.AddProcess may fail but this shouldn't be a reason to cancel the whole window embedding. If it fails, a warning message is logged instead. 

