### PR TITLE
Resolve `WFO1000` build warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,9 @@ jobs:
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.304
+        dotnet-version: '9.0'
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-<!--        <TargetFramework>net462</TargetFramework>-->
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
         <ImplicitUsings>false</ImplicitUsings>
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net9.0-windows</TargetFramework>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <OutputType>WinExe</OutputType>
         <UseWindowsForms>true</UseWindowsForms>

--- a/src/RoyalApps.Community.ExternalApps.WinForms/ExternalAppHost.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/ExternalAppHost.cs
@@ -16,6 +16,7 @@ using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.Storage.Xps;
 using Windows.Win32.UI.Accessibility;
 using Windows.Win32.UI.WindowsAndMessaging;
+using System.ComponentModel;
 // ReSharper disable CommentTypo
 // ReSharper disable StringLiteralTypo
 
@@ -36,6 +37,7 @@ public class ExternalAppHost : Control
     /// <summary>
     /// The Handle property as HWND.
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     internal HWND ControlHandle { get; private set; }
 
     private ExternalApp? _externalApp;
@@ -45,6 +47,7 @@ public class ExternalAppHost : Control
     /// Gets or sets the <see cref="ILoggerFactory" /> used to create instances of <see cref="ILogger" />.
     /// Defaults to <see cref="NullLoggerFactory" />.
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ILoggerFactory LoggerFactory { get; set; }
 
     /// <summary>

--- a/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
@@ -16,7 +16,7 @@
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);NU1603,NU1701,NU5100,CS8981;WFO1000</NoWarn>
+        <NoWarn>$(NoWarn);NU1603,NU1701,NU5100,CS8981</NoWarn>
         <Configurations>Debug;Release</Configurations>
         <Platforms>AnyCPU;x64;ARM64</Platforms>
     </PropertyGroup>


### PR DESCRIPTION
Resolve build warning/error (new in `net9.0`):

> Error WFO1000: Property 'ABC' does not configure the code serialization for its property content