### PR TITLE
Unambiguous .NET Framework version

### DIFF
--- a/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net472;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks>net4.7.2;net8.0-windows;net9.0-windows</TargetFrameworks>
         <RuntimeIdentifier Condition="$(Platform) == 'x64'">win-x64</RuntimeIdentifier>
         <RuntimeIdentifier Condition="$(Platform) == 'ARM64'">win-arm64</RuntimeIdentifier>
         <UseWindowsForms>true</UseWindowsForms>


### PR DESCRIPTION
Specify the .NET Framework version using dotted-form. 

ref. https://github.com/dotnet/designs/pull/322:

> We want to steer people towards a proper version syntax, that is
>
> ```xml
> <TargetFramework>netX.Y.Z</TargetFramework>
> ```
>
> Examples include `net9.0`, `net10.0`, `net4.5.1`. This syntax makes it unambiguous.