### PR TITLE
Strip UTF-8 BOM from source files

### DIFF
--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/Extensions/ControlExtensions.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/Extensions/ControlExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.Demo.Extensions;

--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/FormMain.Designer.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/FormMain.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.Demo;
 

--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/FormMain.resx
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/FormMain.resx
@@ -1,4 +1,4 @@
-﻿<root>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Nullable>enable</Nullable>

--- a/src/RoyalApps.Community.ExternalApps.WinForms/ApplicationClosedEventArgs.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/ApplicationClosedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.ExternalApps.WinForms;
 

--- a/src/RoyalApps.Community.ExternalApps.WinForms/Extensions/LoggerExtensions.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/Extensions/LoggerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;

--- a/src/RoyalApps.Community.ExternalApps.WinForms/Extensions/SecureStringExtensions.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/Extensions/SecureStringExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.Extensions;

--- a/src/RoyalApps.Community.ExternalApps.WinForms/ExternalAppHost.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/ExternalAppHost.cs
@@ -1,4 +1,4 @@
-﻿using RoyalApps.Community.ExternalApps.WinForms.Extensions;
+using RoyalApps.Community.ExternalApps.WinForms.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RoyalApps.Community.ExternalApps.WinForms.WindowManagement;

--- a/src/RoyalApps.Community.ExternalApps.WinForms/ExternalApps.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/ExternalApps.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/RoyalApps.Community.ExternalApps.WinForms/Native/Api.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/Native/Api.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.Native;
 

--- a/src/RoyalApps.Community.ExternalApps.WinForms/NativeMethods.json
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/NativeMethods.json
@@ -1,3 +1,3 @@
-﻿{
+{
   "$schema": "https://aka.ms/CsWin32.schema.json"
 }

--- a/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/MissingWindowException.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/MissingWindowException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.WindowManagement;
 

--- a/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ProcessJobTracker.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ProcessJobTracker.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable CommentTypo
+// ReSharper disable CommentTypo
 
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license.

--- a/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ProcessWindowInfo.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ProcessWindowInfo.cs
@@ -1,4 +1,4 @@
-﻿using Windows.Win32.Foundation;
+using Windows.Win32.Foundation;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.WindowManagement;
 

--- a/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ProcessWindowProvider.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/ProcessWindowProvider.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/QueryWindowEventArgs.cs
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/WindowManagement/QueryWindowEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.ExternalApps.WinForms.WindowManagement;
 

--- a/src/RoyalApps.Community.ExternalApps.slnx
+++ b/src/RoyalApps.Community.ExternalApps.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Folder Name="/Solution Items/">
     <File Path="..\.gitignore" />
     <File Path="..\README.md" />

--- a/src/WinEmbed/WinEmbed.sln
+++ b/src/WinEmbed/WinEmbed.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31825.309

--- a/src/WinEmbed/WinEmbed/WinEmbed.vcxproj.filters
+++ b/src/WinEmbed/WinEmbed/WinEmbed.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
The byte-order marks are not necessary on any platform -- C#, .NET and current IDEs handle UTF-8 files just fine without them.