### PR TITLE
Add .NET 10 target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <OutputType>WinExe</OutputType>
         <UseWindowsForms>true</UseWindowsForms>
@@ -24,9 +24,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
-      <PackageReference Include="System.Text.Json" Version="9.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.7.25380.108" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25380.108" />
     </ItemGroup>
 
 </Project>

--- a/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms.Demo/RoyalApps.Community.ExternalApps.WinForms.Demo.csproj
@@ -24,8 +24,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.7.25380.108" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25380.108" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-rc.1.25451.107" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25451.107" />
     </ItemGroup>
 
 </Project>

--- a/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
@@ -78,13 +78,13 @@
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
-        <PackageReference Include="System.Management" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+        <PackageReference Include="System.Management" Version="9.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25380.108" />
-        <PackageReference Include="System.Management" Version="10.0.0-preview.7.25380.108" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25451.107" />
+        <PackageReference Include="System.Management" Version="10.0.0-rc.1.25451.107" />
     </ItemGroup>
 
 </Project>

--- a/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
+++ b/src/RoyalApps.Community.ExternalApps.WinForms/RoyalApps.Community.ExternalApps.WinForms.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0-windows;net8.0-windows;net4.7.2</TargetFrameworks>
+        <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows;net4.7.2</TargetFrameworks>
         <RuntimeIdentifier Condition="$(Platform) == 'x64'">win-x64</RuntimeIdentifier>
         <RuntimeIdentifier Condition="$(Platform) == 'ARM64'">win-arm64</RuntimeIdentifier>
         <UseWindowsForms>true</UseWindowsForms>
@@ -80,6 +80,11 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
         <PackageReference Include="System.Management" Version="9.0.8" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25380.108" />
+        <PackageReference Include="System.Management" Version="10.0.0-preview.7.25380.108" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Not ready for merging/release yet (RC1 needed for go-live) but sufficient for pre-release testing.

Remove `System.Text.Json` reference (flagged as unnecessary ref. https://github.com/NuGet/Home/blob/dev/accepted/2024/prune-package-reference.md)